### PR TITLE
fixed bug with abnormally low loss when running training_bevo.py

### DIFF
--- a/modeling_bevo.py
+++ b/modeling_bevo.py
@@ -147,7 +147,7 @@ class BevoForCausalLM(PreTrainedModel):
     def __init__(self, config):
         super().__init__(config=config)
         assert config.seq_len is not None
-        
+
         self.transformer = nn.ModuleDict(dict(
             wte = nn.Embedding(config.vocab_size, config.hidden_size),
             wpe = nn.Embedding(config.max_position_embeddings, config.hidden_size),
@@ -202,18 +202,20 @@ class BevoForCausalLM(PreTrainedModel):
         for block in self.transformer.h:
             x = block(x)
         x = self.transformer.ln_f(x)
-        
+
         logits = self.lm_head(x)
-        
+
+        #NOTE: see how this is slightly modified... (starting with logits = ... above)
         if labels is not None:
             # if we are given some desired labels also calculate the loss
             # Shift so that tokens < n predict n
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
+            #NOTE Now shifting the logits in the data & tokenizing preprocess (tokenize_and_split_seq), not here...
+#            shift_logits = logits[..., :-1, :].contiguous()
+#            shift_labels = labels[..., 1:].contiguous()
             loss = F.cross_entropy(logits.view(-1, logits.size(-1)), labels.view(-1), ignore_index=2)
         else:
             loss = None
-            
+
         return {'logits': logits, 'loss': loss}
 
     def configure_optimizers(self, weight_decay, learning_rate, betas, device_type):


### PR DESCRIPTION
The bug causing the very low loss values when running training_bevo.py has to do with how shifting the token sequence was done. When commenting out the lines starting with shift_logits = and shift_labels =  in modeling_bevo.py , and doing the shifting during data preparation (in function tokenize_and_split_seq by shifting the input_ids to the right by 1 and starting it with <pad>**), the train loss looks pretty close to the nanoGPT run and a bit lower than the OPT runs (e.g., 2.27 after 2760 steps... val loss is now plateauing at around 4.2).

** maybe <pad> is not the way to start?  Maybe it would be better to instead shift the targets/labels (the way nanoGPT does it).

NOTE: I had to switch dtype to 'float16' since 'bfloag16' didn't work for me. If it's an issue perhaps we can make it a command like argument.